### PR TITLE
[#50] Upgrade to MongoDB 3.0 along with co-mongo/node-mongo when stable versions are out

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ KOAN Stack is a boilerplate that provides a nice starting point for full stack J
 Browse the live KOAN example on [https://koan.herokuapp.com](https://koan.herokuapp.com) which is a Facebook like real-time sharing app.
 
 ## Getting Started
-Make sure that you have Node.js v0.12 or v4.x, and MongoDB v2.x (running on the default port 27017) installed on your computer. To get started with KOAN stack, do following:
+Make sure that you have Node.js v0.12 or v4.x, and MongoDB v3.x (running on the default port 27017) installed on your computer. To get started with KOAN stack, do following:
 
 ```bash
 git clone --depth 1 https://github.com/soygul/koan.git

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "koa-route": "2.4.2",
     "koa-send": "3.1.0",
     "lodash": "3.10.1",
-    "mongodb": "^2.1.4",
+    "mongodb": "2.1.4",
     "ws": "0.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "bower": "1.6.5",
     "co": "4.6.0",
-    "co-mongo": "0.0.2",
     "co-request": "1.0.0",
     "forever": "0.15.1",
     "grunt-cli": "0.1.13",
@@ -34,6 +33,7 @@
     "koa-route": "2.4.2",
     "koa-send": "3.1.0",
     "lodash": "3.10.1",
+    "mongodb": "^2.1.4",
     "ws": "0.8.0"
   },
   "devDependencies": {

--- a/server/config/mongo.js
+++ b/server/config/mongo.js
@@ -6,40 +6,40 @@
  * See /controllers directory for sample usage.
  */
 
-var comongo = require('co-mongo'),
-    connect = comongo.connect,
+var mongodb = require('mongodb'),
+    connect = mongodb.connect,
     config = require('./config');
 
 // extending and exposing top co-mongo namespace like this is not optimal but it saves the user from one extra require();
-module.exports = comongo;
+module.exports = mongodb;
 
 /**
  * Opens a new connection to the mongo database, closing the existing one if exists.
  */
-comongo.connect = function *() {
-  if (comongo.db) {
-    yield comongo.db.close();
+mongodb.connect = function *() {
+  if (mongodb.db) {
+    yield mongodb.db.close();
   }
 
   // export mongo db instance
-  var db = comongo.db = yield connect(config.mongo.url);
+  var db = mongodb.db = yield connect(config.mongo.url);
 
   // export default collections
-  comongo.counters = yield db.collection('counters');
-  comongo.users = yield db.collection('users');
-  comongo.posts = yield db.collection('posts');
+  mongodb.counters = db.collection('counters');
+  mongodb.users = db.collection('users');
+  mongodb.posts = db.collection('posts');
 };
 
 /**
  * Retrieves the next sequence number for the given counter (indicated by @counterName).
  * Useful for generating sequential integer IDs for certain collections (i.e. user collection).
  */
-comongo.getNextSequence = function *(counterName) {
-  var results = yield comongo.counters.findAndModify(
+mongodb.getNextSequence = function *(counterName) {
+  var results = yield mongodb.counters.findAndModify(
       {_id: counterName},
       [],
       {$inc: {seq: 1}},
       {new: true}
   );
-  return results[0].seq;
+  return results.value.seq;
 };

--- a/server/controllers/posts.js
+++ b/server/controllers/posts.js
@@ -41,10 +41,10 @@ function *createPost() {
   var post = this.request.body;
   post.from = this.state.user; // user info is stored in 'this.state.user' field after successful login, as suggested by Koa docs: http://koajs.com/#ctx-state
   post.createdTime = new Date();
-  var results = yield mongo.posts.insert(post);
+  var results = yield mongo.posts.insertOne(post);
 
   this.status = 201;
-  this.body = {id: results[0]._id};
+  this.body = {id: results.ops[0]._id};
 
   // now notify everyone about this new post
   post.id = post._id;

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -23,8 +23,8 @@ function *createUser() {
   // get the latest userId+1 as the new user id
   // this is exceptional to user creation as we want user ids to be sequential numbers and not standard mongo guids
   user._id = yield mongo.getNextSequence('userId');
-  var results = yield mongo.users.insert(user);
-
+  var results = yield mongo.users.insertOne(user);
+  
   this.status = 201;
-  this.body = {id: results[0]._id};
+  this.body = {id: results.ops[0]._id};
 }


### PR DESCRIPTION
Hi @soygul,
It looks like mongodb native driver supports ES6 and generators by the way. This task can be done without updating co-mongo.

Api of mongodb is a little bit changed. I made some changes to use new API.